### PR TITLE
Add limit parameter

### DIFF
--- a/CRM/BulkMailing/BAO/Delete.php
+++ b/CRM/BulkMailing/BAO/Delete.php
@@ -42,6 +42,7 @@ class CRM_BulkMailing_BAO_Delete {
    * @param integer $mailingId
    */
   public static function getMailingIdsFromParams($params) {
+    $limit = empty($params['limit']) ? 0 : $params['limit'];
     if (!empty($params['mailing_ids'])) {
       $mailingIds = explode(',', $params['mailing_ids']);
     }
@@ -50,7 +51,7 @@ class CRM_BulkMailing_BAO_Delete {
         'sequential' => 1,
         'return' => array("id"),
         'scheduled_date' => array('<' => $params['delivered_date_before']),
-        'options' => array('limit' => 0),
+        'options' => array('limit' => $limit),
       ));
       if (!empty($mailing['count'])) {
         $mailingIds = CRM_Utils_Array::collect('id', $mailing['values']);
@@ -95,13 +96,6 @@ class CRM_BulkMailing_BAO_Delete {
       civicrm_api3('Activity', 'delete', array(
         'id' => $activity['id'],
       ));
-      if (Civi::settings()->get('logging')) {
-        CRM_Core_DAO::executeQuery("DELETE FROM log_civicrm_activity WHERE id = {$activity['id']}");
-        CRM_Core_DAO::executeQuery("DELETE FROM log_civicrm_activity_contact WHERE activity_id = {$activity['id']}");
-      }
-    }
-    if (Civi::settings()->get('logging')) {
-      CRM_Core_DAO::executeQuery("DELETE FROM log_civicrm_mailing WHERE id = {$mailingId}");
     }
   }
 

--- a/CRM/BulkMailing/BAO/Delete.php
+++ b/CRM/BulkMailing/BAO/Delete.php
@@ -57,8 +57,8 @@ class CRM_BulkMailing_BAO_Delete {
         $mailingIds = CRM_Utils_Array::collect('id', $mailing['values']);
       }
     }
-    else {
-      throw new API_Exception('Unknown Parameters', 1234);
+    elseif (!$limit) {
+      throw new API_Exception('Missing or Unknown Parameters', 1234);
     }
     return $mailingIds;
   }

--- a/api/v3/Bulkmailing/Deleteoldrecords.mgd.php
+++ b/api/v3/Bulkmailing/Deleteoldrecords.mgd.php
@@ -16,7 +16,7 @@ return array (
       'run_frequency' => 'Daily',
       'api_entity' => 'Bulkmailing',
       'api_action' => 'Deleteoldrecords',
-      'parameters' => "mailing_ids=[comma separated mailing ids]\ndelivered_date_before=yyyy-mm-dd",
+      'parameters' => "limit=1\nmailing_ids=[comma separated mailing ids]\ndelivered_date_before=yyyy-mm-dd",
     ),
   ),
 );

--- a/api/v3/Bulkmailing/Deleteoldrecords.php
+++ b/api/v3/Bulkmailing/Deleteoldrecords.php
@@ -10,9 +10,9 @@
  */
 function civicrm_api3_bulkmailing_Deleteoldrecords($params) {
   $logging = new CRM_Logging_Schema();
-  $logging->disableLogging();
+  // $logging->disableLogging();
   CRM_BulkMailing_BAO_Delete::delete($params);
-  $logging->enableLogging();
+  // $logging->enableLogging();
   // Spec: civicrm_api3_create_success($values = 1, $params = array(), $entity = NULL, $action = NULL)
   return civicrm_api3_create_success(array(), $params, 'BulkMailing', 'DeleteOldRecords');
 }

--- a/api/v3/Bulkmailing/Deleteoldrecords.php
+++ b/api/v3/Bulkmailing/Deleteoldrecords.php
@@ -1,5 +1,17 @@
 <?php
 /**
+ *
+ */
+function _civicrm_api3_bulkmailing_Deleteoldrecords_spec(&$spec) {
+  $spec['limit'] = array(
+    'name' => 'limit',
+    'title' => 'Limit number of mailings deleted.',
+    'api.required' => 0,
+    'type' => 1,
+  );
+}
+
+/**
  * Bulkmailing.Deleteoldrecords API
  *
  * @param array $params

--- a/deleteoldbulkmailings.civix.php
+++ b/deleteoldbulkmailings.civix.php
@@ -24,7 +24,7 @@ class CRM_Deleteoldbulkmailings_ExtensionUtil {
    *   Translated text.
    * @see ts
    */
-  public static function ts($text, $params = []) {
+  public static function ts($text, $params = []): string {
     if (!array_key_exists('domain', $params)) {
       $params['domain'] = [self::LONG_NAME, NULL];
     }
@@ -41,7 +41,7 @@ class CRM_Deleteoldbulkmailings_ExtensionUtil {
    *   Ex: 'http://example.org/sites/default/ext/org.example.foo'.
    *   Ex: 'http://example.org/sites/default/ext/org.example.foo/css/foo.css'.
    */
-  public static function url($file = NULL) {
+  public static function url($file = NULL): string {
     if ($file === NULL) {
       return rtrim(CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME), '/');
     }
@@ -79,45 +79,29 @@ class CRM_Deleteoldbulkmailings_ExtensionUtil {
 
 use CRM_Deleteoldbulkmailings_ExtensionUtil as E;
 
+function _deleteoldbulkmailings_civix_mixin_polyfill() {
+  if (!class_exists('CRM_Extension_MixInfo')) {
+    $polyfill = __DIR__ . '/mixin/polyfill.php';
+    (require $polyfill)(E::LONG_NAME, E::SHORT_NAME, E::path());
+  }
+}
+
 /**
  * (Delegated) Implements hook_civicrm_config().
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_config
  */
-function _deleteoldbulkmailings_civix_civicrm_config(&$config = NULL) {
+function _deleteoldbulkmailings_civix_civicrm_config($config = NULL) {
   static $configured = FALSE;
   if ($configured) {
     return;
   }
   $configured = TRUE;
 
-  $template =& CRM_Core_Smarty::singleton();
-
-  $extRoot = dirname(__FILE__) . DIRECTORY_SEPARATOR;
-  $extDir = $extRoot . 'templates';
-
-  if (is_array($template->template_dir)) {
-    array_unshift($template->template_dir, $extDir);
-  }
-  else {
-    $template->template_dir = [$extDir, $template->template_dir];
-  }
-
+  $extRoot = __DIR__ . DIRECTORY_SEPARATOR;
   $include_path = $extRoot . PATH_SEPARATOR . get_include_path();
   set_include_path($include_path);
-}
-
-/**
- * (Delegated) Implements hook_civicrm_xmlMenu().
- *
- * @param $files array(string)
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_xmlMenu
- */
-function _deleteoldbulkmailings_civix_civicrm_xmlMenu(&$files) {
-  foreach (_deleteoldbulkmailings_civix_glob(__DIR__ . '/xml/Menu/*.xml') as $file) {
-    $files[] = $file;
-  }
+  _deleteoldbulkmailings_civix_mixin_polyfill();
 }
 
 /**
@@ -127,35 +111,7 @@ function _deleteoldbulkmailings_civix_civicrm_xmlMenu(&$files) {
  */
 function _deleteoldbulkmailings_civix_civicrm_install() {
   _deleteoldbulkmailings_civix_civicrm_config();
-  if ($upgrader = _deleteoldbulkmailings_civix_upgrader()) {
-    $upgrader->onInstall();
-  }
-}
-
-/**
- * Implements hook_civicrm_postInstall().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_postInstall
- */
-function _deleteoldbulkmailings_civix_civicrm_postInstall() {
-  _deleteoldbulkmailings_civix_civicrm_config();
-  if ($upgrader = _deleteoldbulkmailings_civix_upgrader()) {
-    if (is_callable([$upgrader, 'onPostInstall'])) {
-      $upgrader->onPostInstall();
-    }
-  }
-}
-
-/**
- * Implements hook_civicrm_uninstall().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_uninstall
- */
-function _deleteoldbulkmailings_civix_civicrm_uninstall() {
-  _deleteoldbulkmailings_civix_civicrm_config();
-  if ($upgrader = _deleteoldbulkmailings_civix_upgrader()) {
-    $upgrader->onUninstall();
-  }
+  _deleteoldbulkmailings_civix_mixin_polyfill();
 }
 
 /**
@@ -163,212 +119,9 @@ function _deleteoldbulkmailings_civix_civicrm_uninstall() {
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_enable
  */
-function _deleteoldbulkmailings_civix_civicrm_enable() {
+function _deleteoldbulkmailings_civix_civicrm_enable(): void {
   _deleteoldbulkmailings_civix_civicrm_config();
-  if ($upgrader = _deleteoldbulkmailings_civix_upgrader()) {
-    if (is_callable([$upgrader, 'onEnable'])) {
-      $upgrader->onEnable();
-    }
-  }
-}
-
-/**
- * (Delegated) Implements hook_civicrm_disable().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_disable
- * @return mixed
- */
-function _deleteoldbulkmailings_civix_civicrm_disable() {
-  _deleteoldbulkmailings_civix_civicrm_config();
-  if ($upgrader = _deleteoldbulkmailings_civix_upgrader()) {
-    if (is_callable([$upgrader, 'onDisable'])) {
-      $upgrader->onDisable();
-    }
-  }
-}
-
-/**
- * (Delegated) Implements hook_civicrm_upgrade().
- *
- * @param $op string, the type of operation being performed; 'check' or 'enqueue'
- * @param $queue CRM_Queue_Queue, (for 'enqueue') the modifiable list of pending up upgrade tasks
- *
- * @return mixed
- *   based on op. for 'check', returns array(boolean) (TRUE if upgrades are pending)
- *   for 'enqueue', returns void
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_upgrade
- */
-function _deleteoldbulkmailings_civix_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
-  if ($upgrader = _deleteoldbulkmailings_civix_upgrader()) {
-    return $upgrader->onUpgrade($op, $queue);
-  }
-}
-
-/**
- * @return CRM_Deleteoldbulkmailings_Upgrader
- */
-function _deleteoldbulkmailings_civix_upgrader() {
-  if (!file_exists(__DIR__ . '/CRM/Deleteoldbulkmailings/Upgrader.php')) {
-    return NULL;
-  }
-  else {
-    return CRM_Deleteoldbulkmailings_Upgrader_Base::instance();
-  }
-}
-
-/**
- * Search directory tree for files which match a glob pattern.
- *
- * Note: Dot-directories (like "..", ".git", or ".svn") will be ignored.
- * Note: In Civi 4.3+, delegate to CRM_Utils_File::findFiles()
- *
- * @param string $dir base dir
- * @param string $pattern , glob pattern, eg "*.txt"
- *
- * @return array
- */
-function _deleteoldbulkmailings_civix_find_files($dir, $pattern) {
-  if (is_callable(['CRM_Utils_File', 'findFiles'])) {
-    return CRM_Utils_File::findFiles($dir, $pattern);
-  }
-
-  $todos = [$dir];
-  $result = [];
-  while (!empty($todos)) {
-    $subdir = array_shift($todos);
-    foreach (_deleteoldbulkmailings_civix_glob("$subdir/$pattern") as $match) {
-      if (!is_dir($match)) {
-        $result[] = $match;
-      }
-    }
-    if ($dh = opendir($subdir)) {
-      while (FALSE !== ($entry = readdir($dh))) {
-        $path = $subdir . DIRECTORY_SEPARATOR . $entry;
-        if ($entry[0] == '.') {
-        }
-        elseif (is_dir($path)) {
-          $todos[] = $path;
-        }
-      }
-      closedir($dh);
-    }
-  }
-  return $result;
-}
-
-/**
- * (Delegated) Implements hook_civicrm_managed().
- *
- * Find any *.mgd.php files, merge their content, and return.
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_managed
- */
-function _deleteoldbulkmailings_civix_civicrm_managed(&$entities) {
-  $mgdFiles = _deleteoldbulkmailings_civix_find_files(__DIR__, '*.mgd.php');
-  sort($mgdFiles);
-  foreach ($mgdFiles as $file) {
-    $es = include $file;
-    foreach ($es as $e) {
-      if (empty($e['module'])) {
-        $e['module'] = E::LONG_NAME;
-      }
-      if (empty($e['params']['version'])) {
-        $e['params']['version'] = '3';
-      }
-      $entities[] = $e;
-    }
-  }
-}
-
-/**
- * (Delegated) Implements hook_civicrm_caseTypes().
- *
- * Find any and return any files matching "xml/case/*.xml"
- *
- * Note: This hook only runs in CiviCRM 4.4+.
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_caseTypes
- */
-function _deleteoldbulkmailings_civix_civicrm_caseTypes(&$caseTypes) {
-  if (!is_dir(__DIR__ . '/xml/case')) {
-    return;
-  }
-
-  foreach (_deleteoldbulkmailings_civix_glob(__DIR__ . '/xml/case/*.xml') as $file) {
-    $name = preg_replace('/\.xml$/', '', basename($file));
-    if ($name != CRM_Case_XMLProcessor::mungeCaseType($name)) {
-      $errorMessage = sprintf("Case-type file name is malformed (%s vs %s)", $name, CRM_Case_XMLProcessor::mungeCaseType($name));
-      throw new CRM_Core_Exception($errorMessage);
-    }
-    $caseTypes[$name] = [
-      'module' => E::LONG_NAME,
-      'name' => $name,
-      'file' => $file,
-    ];
-  }
-}
-
-/**
- * (Delegated) Implements hook_civicrm_angularModules().
- *
- * Find any and return any files matching "ang/*.ang.php"
- *
- * Note: This hook only runs in CiviCRM 4.5+.
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_angularModules
- */
-function _deleteoldbulkmailings_civix_civicrm_angularModules(&$angularModules) {
-  if (!is_dir(__DIR__ . '/ang')) {
-    return;
-  }
-
-  $files = _deleteoldbulkmailings_civix_glob(__DIR__ . '/ang/*.ang.php');
-  foreach ($files as $file) {
-    $name = preg_replace(':\.ang\.php$:', '', basename($file));
-    $module = include $file;
-    if (empty($module['ext'])) {
-      $module['ext'] = E::LONG_NAME;
-    }
-    $angularModules[$name] = $module;
-  }
-}
-
-/**
- * (Delegated) Implements hook_civicrm_themes().
- *
- * Find any and return any files matching "*.theme.php"
- */
-function _deleteoldbulkmailings_civix_civicrm_themes(&$themes) {
-  $files = _deleteoldbulkmailings_civix_glob(__DIR__ . '/*.theme.php');
-  foreach ($files as $file) {
-    $themeMeta = include $file;
-    if (empty($themeMeta['name'])) {
-      $themeMeta['name'] = preg_replace(':\.theme\.php$:', '', basename($file));
-    }
-    if (empty($themeMeta['ext'])) {
-      $themeMeta['ext'] = E::LONG_NAME;
-    }
-    $themes[$themeMeta['name']] = $themeMeta;
-  }
-}
-
-/**
- * Glob wrapper which is guaranteed to return an array.
- *
- * The documentation for glob() says, "On some systems it is impossible to
- * distinguish between empty match and an error." Anecdotally, the return
- * result for an empty match is sometimes array() and sometimes FALSE.
- * This wrapper provides consistency.
- *
- * @link http://php.net/glob
- * @param string $pattern
- *
- * @return array
- */
-function _deleteoldbulkmailings_civix_glob($pattern) {
-  $result = glob($pattern);
-  return is_array($result) ? $result : [];
+  _deleteoldbulkmailings_civix_mixin_polyfill();
 }
 
 /**
@@ -387,8 +140,8 @@ function _deleteoldbulkmailings_civix_insert_navigation_menu(&$menu, $path, $ite
   if (empty($path)) {
     $menu[] = [
       'attributes' => array_merge([
-        'label'      => CRM_Utils_Array::value('name', $item),
-        'active'     => 1,
+        'label' => $item['name'] ?? NULL,
+        'active' => 1,
       ], $item),
     ];
     return TRUE;
@@ -451,27 +204,4 @@ function _deleteoldbulkmailings_civix_fixNavigationMenuItems(&$nodes, &$maxNavID
       _deleteoldbulkmailings_civix_fixNavigationMenuItems($nodes[$origKey]['child'], $maxNavID, $nodes[$origKey]['attributes']['navID']);
     }
   }
-}
-
-/**
- * (Delegated) Implements hook_civicrm_alterSettingsFolders().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_alterSettingsFolders
- */
-function _deleteoldbulkmailings_civix_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
-  $settingsDir = __DIR__ . DIRECTORY_SEPARATOR . 'settings';
-  if (!in_array($settingsDir, $metaDataFolders) && is_dir($settingsDir)) {
-    $metaDataFolders[] = $settingsDir;
-  }
-}
-
-/**
- * (Delegated) Implements hook_civicrm_entityTypes().
- *
- * Find any *.entityType.php files, merge their content, and return.
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_entityTypes
- */
-function _deleteoldbulkmailings_civix_civicrm_entityTypes(&$entityTypes) {
-  $entityTypes = array_merge($entityTypes, []);
 }

--- a/deleteoldbulkmailings.php
+++ b/deleteoldbulkmailings.php
@@ -13,39 +13,12 @@ function deleteoldbulkmailings_civicrm_config(&$config) {
 }
 
 /**
- * Implements hook_civicrm_xmlMenu().
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_xmlMenu
- */
-function deleteoldbulkmailings_civicrm_xmlMenu(&$files) {
-  _deleteoldbulkmailings_civix_civicrm_xmlMenu($files);
-}
-
-/**
  * Implements hook_civicrm_install().
  *
  * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_install
  */
 function deleteoldbulkmailings_civicrm_install() {
   _deleteoldbulkmailings_civix_civicrm_install();
-}
-
-/**
- * Implements hook_civicrm_postInstall().
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_postInstall
- */
-function deleteoldbulkmailings_civicrm_postInstall() {
-  _deleteoldbulkmailings_civix_civicrm_postInstall();
-}
-
-/**
- * Implements hook_civicrm_uninstall().
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_uninstall
- */
-function deleteoldbulkmailings_civicrm_uninstall() {
-  _deleteoldbulkmailings_civix_civicrm_uninstall();
 }
 
 /**
@@ -56,73 +29,6 @@ function deleteoldbulkmailings_civicrm_uninstall() {
 function deleteoldbulkmailings_civicrm_enable() {
   _deleteoldbulkmailings_civix_civicrm_enable();
 }
-
-/**
- * Implements hook_civicrm_disable().
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_disable
- */
-function deleteoldbulkmailings_civicrm_disable() {
-  _deleteoldbulkmailings_civix_civicrm_disable();
-}
-
-/**
- * Implements hook_civicrm_upgrade().
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_upgrade
- */
-function deleteoldbulkmailings_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
-  return _deleteoldbulkmailings_civix_civicrm_upgrade($op, $queue);
-}
-
-/**
- * Implements hook_civicrm_managed().
- *
- * Generate a list of entities to create/deactivate/delete when this module
- * is installed, disabled, uninstalled.
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_managed
- */
-function deleteoldbulkmailings_civicrm_managed(&$entities) {
-  _deleteoldbulkmailings_civix_civicrm_managed($entities);
-}
-
-/**
- * Implements hook_civicrm_caseTypes().
- *
- * Generate a list of case-types.
- *
- * Note: This hook only runs in CiviCRM 4.4+.
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_caseTypes
- */
-function deleteoldbulkmailings_civicrm_caseTypes(&$caseTypes) {
-  _deleteoldbulkmailings_civix_civicrm_caseTypes($caseTypes);
-}
-
-/**
- * Implements hook_civicrm_angularModules().
- *
- * Generate a list of Angular modules.
- *
- * Note: This hook only runs in CiviCRM 4.5+. It may
- * use features only available in v4.6+.
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_angularModules
- */
-function deleteoldbulkmailings_civicrm_angularModules(&$angularModules) {
-  _deleteoldbulkmailings_civix_civicrm_angularModules($angularModules);
-}
-
-/**
- * Implements hook_civicrm_alterSettingsFolders().
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_alterSettingsFolders
- */
-function deleteoldbulkmailings_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
-  _deleteoldbulkmailings_civix_civicrm_alterSettingsFolders($metaDataFolders);
-}
-
 
 /**
  * Implements hook_civicrm_navigationMenu().

--- a/info.xml
+++ b/info.xml
@@ -23,5 +23,13 @@
   <comments>This is a new, undeveloped module</comments>
   <civix>
     <namespace>CRM/Deleteoldbulkmailings</namespace>
+    <format>23.02.1</format>
   </civix>
+  <mixins>
+    <mixin>mgd-php@1.0.0</mixin>
+  </mixins>
+  <classloader>
+    <psr0 prefix="CRM_" path="."/>
+    <psr4 prefix="Civi\" path="Civi"/>
+  </classloader>
 </extension>

--- a/mixin/mgd-php@1.0.0.mixin.php
+++ b/mixin/mgd-php@1.0.0.mixin.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * Auto-register "**.mgd.php" files.
+ *
+ * @mixinName mgd-php
+ * @mixinVersion 1.0.0
+ *
+ * @param CRM_Extension_MixInfo $mixInfo
+ *   On newer deployments, this will be an instance of MixInfo. On older deployments, Civix may polyfill with a work-a-like.
+ * @param \CRM_Extension_BootCache $bootCache
+ *   On newer deployments, this will be an instance of MixInfo. On older deployments, Civix may polyfill with a work-a-like.
+ */
+return function ($mixInfo, $bootCache) {
+
+  /**
+   * @param \Civi\Core\Event\GenericHookEvent $e
+   * @see CRM_Utils_Hook::managed()
+   */
+  Civi::dispatcher()->addListener('hook_civicrm_managed', function ($event) use ($mixInfo) {
+    // When deactivating on a polyfill/pre-mixin system, listeners may not cleanup automatically.
+    if (!$mixInfo->isActive()) {
+      return;
+    }
+
+    $mgdFiles = CRM_Utils_File::findFiles($mixInfo->getPath(), '*.mgd.php');
+    sort($mgdFiles);
+    foreach ($mgdFiles as $file) {
+      $es = include $file;
+      foreach ($es as $e) {
+        if (empty($e['module'])) {
+          $e['module'] = $mixInfo->longName;
+        }
+        if (empty($e['params']['version'])) {
+          $e['params']['version'] = '3';
+        }
+        $event->entities[] = $e;
+      }
+    }
+  });
+
+};

--- a/mixin/polyfill.php
+++ b/mixin/polyfill.php
@@ -1,0 +1,101 @@
+<?php
+
+/**
+ * When deploying on systems that lack mixin support, fake it.
+ *
+ * @mixinFile polyfill.php
+ *
+ * This polyfill does some (persnickity) deduplication, but it doesn't allow upgrades or shipping replacements in core.
+ *
+ * Note: The polyfill.php is designed to be copied into extensions for interoperability. Consequently, this file is
+ * not used 'live' by `civicrm-core`. However, the file does need a canonical home, and it's convenient to keep it
+ * adjacent to the actual mixin files.
+ *
+ * @param string $longName
+ * @param string $shortName
+ * @param string $basePath
+ */
+return function ($longName, $shortName, $basePath) {
+  // Construct imitations of the mixin services. These cannot work as well (e.g. with respect to
+  // number of file-reads, deduping, upgrading)... but they should be OK for a few months while
+  // the mixin services become available.
+
+  // List of active mixins; deduped by version
+  $mixinVers = [];
+  foreach ((array) glob($basePath . '/mixin/*.mixin.php') as $f) {
+    [$name, $ver] = explode('@', substr(basename($f), 0, -10));
+    if (!isset($mixinVers[$name]) || version_compare($ver, $mixinVers[$name], '>')) {
+      $mixinVers[$name] = $ver;
+    }
+  }
+  $mixins = [];
+  foreach ($mixinVers as $name => $ver) {
+    $mixins[] = "$name@$ver";
+  }
+
+  // Imitate CRM_Extension_MixInfo.
+  $mixInfo = new class() {
+
+    /**
+     * @var string
+     */
+    public $longName;
+
+    /**
+     * @var string
+     */
+    public $shortName;
+
+    public $_basePath;
+
+    public function getPath($file = NULL) {
+      return $this->_basePath . ($file === NULL ? '' : (DIRECTORY_SEPARATOR . $file));
+    }
+
+    public function isActive() {
+      return \CRM_Extension_System::singleton()->getMapper()->isActiveModule($this->shortName);
+    }
+
+  };
+  $mixInfo->longName = $longName;
+  $mixInfo->shortName = $shortName;
+  $mixInfo->_basePath = $basePath;
+
+  // Imitate CRM_Extension_BootCache.
+  $bootCache = new class() {
+
+    public function define($name, $callback) {
+      $envId = \CRM_Core_Config_Runtime::getId();
+      $oldExtCachePath = \Civi::paths()->getPath("[civicrm.compile]/CachedExtLoader.{$envId}.php");
+      $stat = stat($oldExtCachePath);
+      $file = Civi::paths()->getPath('[civicrm.compile]/CachedMixin.' . md5($name . ($stat['mtime'] ?? 0)) . '.php');
+      if (file_exists($file)) {
+        return include $file;
+      }
+      else {
+        $data = $callback();
+        file_put_contents($file, '<' . "?php\nreturn " . var_export($data, 1) . ';');
+        return $data;
+      }
+    }
+
+  };
+
+  // Imitate CRM_Extension_MixinLoader::run()
+  // Parse all live mixins before trying to scan any classes.
+  global $_CIVIX_MIXIN_POLYFILL;
+  foreach ($mixins as $mixin) {
+    // If the exact same mixin is defined by multiple exts, just use the first one.
+    if (!isset($_CIVIX_MIXIN_POLYFILL[$mixin])) {
+      $_CIVIX_MIXIN_POLYFILL[$mixin] = include_once $basePath . '/mixin/' . $mixin . '.mixin.php';
+    }
+  }
+  foreach ($mixins as $mixin) {
+    // If there's trickery about installs/uninstalls/resets, then we may need to register a second time.
+    if (!isset(\Civi::$statics[$longName][$mixin])) {
+      \Civi::$statics[$longName][$mixin] = 1;
+      $func = $_CIVIX_MIXIN_POLYFILL[$mixin];
+      $func($mixInfo, $bootCache);
+    }
+  }
+};


### PR DESCRIPTION
Added an optional limit= parameter to the api. For really big installs with a lot of old records, it's nice to run it with a limit parameter first just to confirm it's doing what you want it to do. And if you're running anything automated, a limit parameter is usually a good idea.

The disable/enable logging patch is no longer relevant or included (you fixed this issue since I started my fork).